### PR TITLE
Add versioned API docs workflows

### DIFF
--- a/.github/workflows/docs-run.yml
+++ b/.github/workflows/docs-run.yml
@@ -6,9 +6,6 @@ on:
       react-router-major:
         required: true
         type: string
-      pnpm-version:
-        required: true
-        type: string
 
 permissions:
   contents: write
@@ -63,7 +60,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: ${{ inputs.pnpm-version }}
+          package_json_file: react-router/package.json
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/docs-run.yml
+++ b/.github/workflows/docs-run.yml
@@ -3,9 +3,6 @@ name: Run API Documentation Update
 on:
   workflow_call:
     inputs:
-      react-router-ref:
-        required: true
-        type: string
       react-router-major:
         required: true
         type: string
@@ -32,7 +29,27 @@ jobs:
         with:
           repository: remix-run/react-router
           path: react-router
-          ref: ${{ inputs.react-router-ref }}
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Checkout latest stable react-router tag
+        id: react_router_tag
+        working-directory: react-router
+        run: |
+          latest_tag="$(
+            git tag -l "react-router@${{ inputs.react-router-major }}.*" --sort=-v:refname |
+              grep -E "^react-router@${{ inputs.react-router-major }}\.[0-9]+\.[0-9]+$" |
+              head -n 1
+          )"
+
+          if [ -z "$latest_tag" ]; then
+            echo "Error: No stable react-router v${{ inputs.react-router-major }} tag found"
+            exit 1
+          fi
+
+          git checkout "$latest_tag"
+
+          echo "tag=$latest_tag" >> $GITHUB_OUTPUT
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
@@ -70,7 +87,6 @@ jobs:
             exit 1
           fi
 
-          echo "react_router_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
           echo "docs_dir=v$react_router_major" >> $GITHUB_OUTPUT
 
       - name: Copy documentation
@@ -100,7 +116,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          git commit -m "Updated API documentation from react-router SHA ${{ steps.generate.outputs.react_router_sha }}"
+          git commit -m "Updated API documentation from ${{ steps.react_router_tag.outputs.tag }}"
           git push
 
           echo "Pushed docs changes https://github.com/$GITHUB_REPOSITORY/commit/$(git rev-parse HEAD)"

--- a/.github/workflows/docs-run.yml
+++ b/.github/workflows/docs-run.yml
@@ -1,0 +1,106 @@
+name: Run API Documentation Update
+
+on:
+  workflow_call:
+    inputs:
+      react-router-ref:
+        required: true
+        type: string
+      react-router-major:
+        required: true
+        type: string
+      pnpm-version:
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  docs:
+    name: Update API Documentation (v${{ inputs.react-router-major }})
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout react-router-api-docs
+        uses: actions/checkout@v6
+        with:
+          path: react-router-api-docs
+          ref: main
+
+      - name: Checkout react-router
+        uses: actions/checkout@v6
+        with:
+          repository: remix-run/react-router
+          path: react-router
+          ref: ${{ inputs.react-router-ref }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: ${{ inputs.pnpm-version }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: "pnpm"
+          cache-dependency-path: react-router/pnpm-lock.yaml
+
+      - name: Install dependencies
+        working-directory: react-router
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate documentation
+        id: generate
+        working-directory: react-router
+        run: |
+          pnpm run build
+          pnpm run docs:typedoc
+
+          if [ ! -d "public/dev" ]; then
+            echo "Error: Documentation not generated"
+            exit 1
+          fi
+
+          react_router_version="$(node -p "require('./packages/react-router/package.json').version")"
+          react_router_major="$(echo "$react_router_version" | cut -d'.' -f1)"
+
+          if [ "$react_router_major" != "${{ inputs.react-router-major }}" ]; then
+            echo "Error: Expected react-router v${{ inputs.react-router-major }}, received: $react_router_version"
+            exit 1
+          fi
+
+          echo "react_router_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          echo "docs_dir=v$react_router_major" >> $GITHUB_OUTPUT
+
+      - name: Copy documentation
+        run: |
+          mkdir -p "react-router-api-docs/${{ steps.generate.outputs.docs_dir }}"
+          rm -rf "react-router-api-docs/${{ steps.generate.outputs.docs_dir }}"/*
+          cp -r react-router/public/dev/* "react-router-api-docs/${{ steps.generate.outputs.docs_dir }}/"
+
+      - name: Commit and push changes
+        working-directory: react-router-api-docs
+        run: |
+          git add "${{ steps.generate.outputs.docs_dir }}/"
+
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "No changes detected"
+            exit 0
+          fi
+
+          # Exit if only sitemap.xml changed, which means it was only timestamp updates
+          if [ "$(git diff --name-only --cached | wc -l)" -eq 1 ]; then
+            if [ "$(git diff --name-only --cached)" = "${{ steps.generate.outputs.docs_dir }}/sitemap.xml" ]; then
+              echo "Only sitemap.xml changed (timestamps), skipping commit"
+              exit 0
+            fi
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git commit -m "Updated API documentation from react-router SHA ${{ steps.generate.outputs.react_router_sha }}"
+          git push
+
+          echo "Pushed docs changes https://github.com/$GITHUB_REPOSITORY/commit/$(git rev-parse HEAD)"

--- a/.github/workflows/docs-run.yml
+++ b/.github/workflows/docs-run.yml
@@ -88,11 +88,9 @@ jobs:
             exit 1
           fi
 
-      - name: Copy documentation
-        run: |
-          mkdir -p "react-router-api-docs/${{ steps.react_router_tag.outputs.docs_dir }}"
-          rm -rf "react-router-api-docs/${{ steps.react_router_tag.outputs.docs_dir }}"/*
-          cp -r react-router/public/dev/* "react-router-api-docs/${{ steps.react_router_tag.outputs.docs_dir }}/"
+          mkdir -p "../react-router-api-docs/${{ steps.react_router_tag.outputs.docs_dir }}"
+          rm -rf "../react-router-api-docs/${{ steps.react_router_tag.outputs.docs_dir }}"/*
+          cp -r public/dev/* "../react-router-api-docs/${{ steps.react_router_tag.outputs.docs_dir }}/"
 
       - name: Commit and push changes
         working-directory: react-router-api-docs

--- a/.github/workflows/docs-run.yml
+++ b/.github/workflows/docs-run.yml
@@ -49,7 +49,16 @@ jobs:
 
           git checkout "$latest_tag"
 
+          react_router_version="$(node -p "require('./packages/react-router/package.json').version")"
+          react_router_major="$(echo "$react_router_version" | cut -d'.' -f1)"
+
+          if [ "$react_router_major" != "${{ inputs.react-router-major }}" ]; then
+            echo "Error: Expected react-router v${{ inputs.react-router-major }}, received: $react_router_version"
+            exit 1
+          fi
+
           echo "tag=$latest_tag" >> $GITHUB_OUTPUT
+          echo "docs_dir=v$react_router_major" >> $GITHUB_OUTPUT
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
@@ -79,26 +88,16 @@ jobs:
             exit 1
           fi
 
-          react_router_version="$(node -p "require('./packages/react-router/package.json').version")"
-          react_router_major="$(echo "$react_router_version" | cut -d'.' -f1)"
-
-          if [ "$react_router_major" != "${{ inputs.react-router-major }}" ]; then
-            echo "Error: Expected react-router v${{ inputs.react-router-major }}, received: $react_router_version"
-            exit 1
-          fi
-
-          echo "docs_dir=v$react_router_major" >> $GITHUB_OUTPUT
-
       - name: Copy documentation
         run: |
-          mkdir -p "react-router-api-docs/${{ steps.generate.outputs.docs_dir }}"
-          rm -rf "react-router-api-docs/${{ steps.generate.outputs.docs_dir }}"/*
-          cp -r react-router/public/dev/* "react-router-api-docs/${{ steps.generate.outputs.docs_dir }}/"
+          mkdir -p "react-router-api-docs/${{ steps.react_router_tag.outputs.docs_dir }}"
+          rm -rf "react-router-api-docs/${{ steps.react_router_tag.outputs.docs_dir }}"/*
+          cp -r react-router/public/dev/* "react-router-api-docs/${{ steps.react_router_tag.outputs.docs_dir }}/"
 
       - name: Commit and push changes
         working-directory: react-router-api-docs
         run: |
-          git add "${{ steps.generate.outputs.docs_dir }}/"
+          git add "${{ steps.react_router_tag.outputs.docs_dir }}/"
 
           if [ -z "$(git status --porcelain)" ]; then
             echo "No changes detected"
@@ -107,7 +106,7 @@ jobs:
 
           # Exit if only sitemap.xml changed, which means it was only timestamp updates
           if [ "$(git diff --name-only --cached | wc -l)" -eq 1 ]; then
-            if [ "$(git diff --name-only --cached)" = "${{ steps.generate.outputs.docs_dir }}/sitemap.xml" ]; then
+            if [ "$(git diff --name-only --cached)" = "${{ steps.react_router_tag.outputs.docs_dir }}/sitemap.xml" ]; then
               echo "Only sitemap.xml changed (timestamps), skipping commit"
               exit 0
             fi

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,6 @@ jobs:
     uses: ./.github/workflows/docs-run.yml
     with:
       react-router-major: "8"
-      pnpm-version: "10"
 
   v7:
     name: Update API Documentation (v7)
@@ -25,4 +24,3 @@ jobs:
     uses: ./.github/workflows/docs-run.yml
     with:
       react-router-major: "7"
-      pnpm-version: "9"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,91 +6,25 @@ on:
     - cron: "0 8 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
-  docs:
-    name: Update API Documentation
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout react-router-api-docs
-        uses: actions/checkout@v6
-        with:
-          path: react-router-api-docs
-          ref: main
+  # Add future major versions as another job using the same reusable workflow,
+  # then chain `needs` so each docs update pushes before the next one starts.
+  v8:
+    name: Update API Documentation (v8)
+    uses: ./.github/workflows/docs-run.yml
+    with:
+      react-router-ref: main
+      react-router-major: "8"
+      pnpm-version: "10"
 
-      - name: Checkout react-router
-        uses: actions/checkout@v6
-        with:
-          repository: remix-run/react-router
-          path: react-router
-          ref: main
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
-        with:
-          version: 10
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: "pnpm"
-          cache-dependency-path: react-router/pnpm-lock.yaml
-
-      - name: Install dependencies
-        working-directory: react-router
-        run: pnpm install --frozen-lockfile
-
-      - name: Generate documentation
-        id: generate
-        working-directory: react-router
-        run: |
-          pnpm run build
-          pnpm run docs:typedoc
-
-          if [ ! -d "public/dev" ]; then
-            echo "Error: Documentation not generated"
-            exit 1
-          fi
-
-          react_router_version="$(node -p "require('./packages/react-router/package.json').version")"
-          react_router_major="$(echo "$react_router_version" | cut -d'.' -f1)"
-
-          if [ "$react_router_major" != "7" ] && [ "$react_router_major" != "8" ]; then
-            echo "Error: Unsupported react-router major version: $react_router_version"
-            exit 1
-          fi
-
-          echo "react_router_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-          echo "docs_dir=v$react_router_major" >> $GITHUB_OUTPUT
-
-      - name: Copy documentation
-        run: |
-          mkdir -p "react-router-api-docs/${{ steps.generate.outputs.docs_dir }}"
-          rm -rf "react-router-api-docs/${{ steps.generate.outputs.docs_dir }}"/*
-          cp -r react-router/public/dev/* "react-router-api-docs/${{ steps.generate.outputs.docs_dir }}/"
-
-      - name: Commit and push changes
-        working-directory: react-router-api-docs
-        run: |
-          git add "${{ steps.generate.outputs.docs_dir }}/"
-
-          if [ -z "$(git status --porcelain)" ]; then
-            echo "No changes detected"
-            exit 0
-          fi
-
-          # Exit if only sitemap.xml changed, which means it was only timestamp updates
-          if [ "$(git diff --name-only --cached | wc -l)" -eq 1 ]; then
-            if [ "$(git diff --name-only --cached)" = "${{ steps.generate.outputs.docs_dir }}/sitemap.xml" ]; then
-              echo "Only sitemap.xml changed (timestamps), skipping commit"
-              exit 0
-            fi
-          fi
-
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-          git commit -m "Updated API documentation from react-router SHA ${{ steps.generate.outputs.react_router_sha }}"
-          git push
-
-          echo "Pushed docs changes https://github.com/$GITHUB_REPOSITORY/commit/$(git rev-parse HEAD)"
+  v7:
+    name: Update API Documentation (v7)
+    needs: v8
+    uses: ./.github/workflows/docs-run.yml
+    with:
+      react-router-ref: v7
+      react-router-major: "7"
+      pnpm-version: "9"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,13 +10,12 @@ permissions:
   contents: write
 
 jobs:
-  # Add future major versions as another job using the same reusable workflow,
-  # then chain `needs` so each docs update pushes before the next one starts.
+  # Add future major versions as another ordered job using the same reusable
+  # workflow, then chain `needs` so each docs update pushes before the next one starts.
   v8:
     name: Update API Documentation (v8)
     uses: ./.github/workflows/docs-run.yml
     with:
-      react-router-ref: main
       react-router-major: "8"
       pnpm-version: "10"
 
@@ -25,6 +24,5 @@ jobs:
     needs: v8
     uses: ./.github/workflows/docs-run.yml
     with:
-      react-router-ref: v7
       react-router-major: "7"
       pnpm-version: "9"


### PR DESCRIPTION
## Summary
- move the API docs implementation into a reusable workflow
- run v8 docs first, then v7 docs, using the latest stable react-router tag for each major
- keep per-major pnpm versions explicit so adding v9 later is a small ordered job addition

## Details
- resolves tags matching react-router@<major>.<minor>.<patch>
- excludes prerelease tags such as alpha, beta, pre, nightly, and canary builds
- commits docs updates with the selected react-router tag in the commit message

## Validation
- ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].each { |f| YAML.load_file(f); puts "YAML OK #{f}" }'
- local regex sanity check selected react-router@8.1.0 over prerelease sample tags